### PR TITLE
Adding tunning curve calculations

### DIFF
--- a/barc4sr/aux_processing.py
+++ b/barc4sr/aux_processing.py
@@ -894,55 +894,33 @@ def write_tuning_curve(file_name: str, flux: np.array, K: np.array, energy: np.a
         intensity_group.create_dataset('K', data=K) 
 
 
-def read_tuning_curve(file_list: List[str]) -> Dict:
+def read_tuning_curve(file_name: str) -> Dict:
     """
     Reads and processes tuning curve data from files.
 
-    This function reads tuning curve data from files specified in 'file_list' and processes 
-    it to compute spectral power, cumulated power, and integrated power.
-
     Parameters:
-        file_list (List[str]): A list of file paths containing tuning curve data.
+        file_name (str): A file path containing tuning curve data.
 
     Returns:
         Dict: A dictionary containing processed tuning curve data with the following keys:
             - 'TC': A dictionary containing various properties of the tuning curve including:
                 - 'energy': Array containing energy values.
-                - 'flux': Array containing spectral flux data..
+                - 'flux': Array containing spectral flux data.
     """
-    energy = []
-    flux = []
 
-    if isinstance(file_list, List) is False:
-        file_list = [file_list]
+    # Process files in the list
+    if file_name.endswith("h5") or file_name.endswith("hdf5"):
+        print(file_name)
+        with h5.File(file_name, "r") as f:
+            energy =  f["XOPPY_SPECTRUM"]["TC"]["energy"][()]
+            flux = f["XOPPY_SPECTRUM"]["TC"]["flux"][()]
+            K = f["XOPPY_SPECTRUM"]["TC"]["K"][()]
 
-    # new and official barc4sr format
-    if file_list[0].endswith("h5") or file_list[0].endswith("hdf5"):
-        for sim in file_list:
-            print(sim)
-            f = h5.File(sim, "r")
-            energy = np.concatenate((energy, f["XOPPY_SPECTRUM"]["TC"]["energy"][()]))
-            flux = np.concatenate((flux, f["XOPPY_SPECTRUM"]["TC"]["flux"][()]))
-            K = np.concatenate((flux, f["XOPPY_SPECTRUM"]["TC"]["K"][()]))
-
-    # SPECTRA format
-    elif file_list[0].endswith("json"):
-        for jsonfile in file_list:
-            f = open(jsonfile)
-            data = json.load(f)
-            f.close()
-
-            energy = np.concatenate((energy, data['Output']['data'][0]))
-            flux = np.concatenate((flux, data['Output']['data'][1]))
-    else:
-        raise ValueError("Invalid file extension.")
-
+    # Dictionary to store results
     tcSRdict = {
-        "TC":{
-            "energy":energy,
+            "energy": energy,
             "flux": flux,
             "K": K
-        }
     }
 
     return tcSRdict

--- a/barc4sr/aux_processing.py
+++ b/barc4sr/aux_processing.py
@@ -872,7 +872,7 @@ def animate_energy_scan(URdict: Dict, file_name: str, **kwargs: Any) -> None:
 # Tuning curves
 #***********************************************************************************
 
-def write_tuning_curve(file_name: str, flux: np.array, energy: np.array) -> None:
+def write_tuning_curve(file_name: str, flux: np.array, K: np.array, energy: np.array) -> None:
     """
     Writes tuning curve data to an HDF5 file.
 
@@ -891,6 +891,7 @@ def write_tuning_curve(file_name: str, flux: np.array, energy: np.array) -> None
         intensity_group = group.create_group('TC')
         intensity_group.create_dataset('energy', data=energy)
         intensity_group.create_dataset('flux', data=flux) 
+        intensity_group.create_dataset('K', data=K) 
 
 
 def read_tuning_curve(file_list: List[str]) -> Dict:
@@ -922,6 +923,7 @@ def read_tuning_curve(file_list: List[str]) -> Dict:
             f = h5.File(sim, "r")
             energy = np.concatenate((energy, f["XOPPY_SPECTRUM"]["TC"]["energy"][()]))
             flux = np.concatenate((flux, f["XOPPY_SPECTRUM"]["TC"]["flux"][()]))
+            K = np.concatenate((flux, f["XOPPY_SPECTRUM"]["TC"]["K"][()]))
 
     # SPECTRA format
     elif file_list[0].endswith("json"):
@@ -939,6 +941,7 @@ def read_tuning_curve(file_list: List[str]) -> Dict:
         "TC":{
             "energy":energy,
             "flux": flux,
+            "K": K
         }
     }
 

--- a/barc4sr/aux_utils.py
+++ b/barc4sr/aux_utils.py
@@ -197,10 +197,6 @@ class ElectronBeam(object):
         self.e_xp = np.sqrt(self.moment_xpxp)
         self.e_yp = np.sqrt(self.moment_ypyp)
 
-    def get_gamma(self) -> float:
-        """Calculate the Lorentz factor (γ) based on the energy of electrons in GeV."""
-        return get_gamma(self.energy_in_GeV)
-    
     def print_rms(self) -> None:
         """
         Prints electron beam rms sizes and divergences 
@@ -208,7 +204,11 @@ class ElectronBeam(object):
         print(f"electron beam:\n\
             >> x/xp = {self.e_x*1e6:0.2f} um vs. {self.e_xp*1e6:0.2f} urad\n\
             >> y/yp = {self.e_y*1e6:0.2f} um vs. {self.e_yp*1e6:0.2f} urad")
-        
+            
+    def get_gamma(self) -> float:
+        """Calculate the Lorentz factor (γ) based on the energy of electrons in GeV."""
+        return get_gamma(self.energy_in_GeV)
+
     def print_attributes(self) -> None:
         """
         Prints all attribute of object
@@ -291,14 +291,11 @@ class MagneticStructure(object):
 
             if "v" in direction:
                 self.K_vertical = K
-
             elif "h" in direction:
                 self.K_horizontal = K
             else:
                 self.K_vertical = np.sqrt(K/2)
                 self.K_horizontal = np.sqrt(K/2)
-
-            self.set_magnetic_field_from_K(self.K_vertical, self.K_horizontal)
 
     def print_resonant_energy(self,  K: float, harmonic: int, eBeamEnergy: float) -> None:
         """
@@ -321,48 +318,21 @@ class MagneticStructure(object):
     # -------------------------------------        
     # undulator/wiggler auxiliary functions
     # -------------------------------------        
-    def set_K_from_magnetic_field(self, B_horizontal: float=None, B_vertical: float=None) -> None:
+    def set_magnetic_field(self, B_horizontal: float=None, B_vertical: float=None) -> None:
         """
         Sets the K-value based on the magnetic field strength.
 
         Args:
-            B_horizontal (float): Magnetic field strength in the horizontal direction.
-            B_vertical (float): Magnetic field strength in the vertical direction.
+            Bx (float): Magnetic field strength in the horizontal direction.
+            By (float): Magnetic field strength in the vertical direction.
         """
         if self.CLASS_NAME.startswith('B'):
             raise ValueError("invalid operation for bending magnet")
         else:
             if B_horizontal is not None:
-                self.K_horizontal = CHARGE * B_horizontal * self.period_length / (2 * PI * MASS * LIGHT)
-                self.B_horizontal = B_horizontal
+                self.Kx = CHARGE * B_horizontal * self.period_length / (2 * PI * MASS * LIGHT)
             if B_vertical is not None:
-                self.K_vertical = CHARGE * B_vertical * self.period_length / (2 * PI * MASS * LIGHT)
-                self.B_vertical = B_vertical
-
-    def set_magnetic_field_from_K(self, K_horizontal: float=None, K_vertical: float=None) -> None:
-        """
-        Sets the magnetic field strength based on the K-value.
-
-        Args:
-            K_horizontal (float): K-value in the horizontal direction.
-            K_vertical (float): K-value in the vertical direction.
-        """
-        if self.CLASS_NAME.startswith('B'):
-            raise ValueError("invalid operation for bending magnet")
-        else:
-            if K_horizontal is not None:
-                if self.K_horizontal is None:
-                    self.B_horizontal = K_horizontal * 2 * PI * MASS * LIGHT / (CHARGE * self.period_length)
-                    self.K_horizontal = K_horizontal
-                else:
-                    self.B_horizontal = self.K_horizontal * 2 * PI * MASS * LIGHT / (CHARGE * self.period_length)
-            if K_vertical is not None:
-                if self.K_vertical is None:
-                    self.B_vertical = K_vertical * 2 * PI * MASS * LIGHT / (CHARGE * self.period_length)
-                    self.K_vertical = K_vertical
-                else:
-                    self.B_vertical = self.K_vertical * 2 * PI * MASS * LIGHT / (CHARGE * self.period_length)
-
+                self.Kx = CHARGE * B_vertical * self.period_length / (2 * PI * MASS * LIGHT)
     # -------------------------------------        
     # bending magnet auxiliary functions
     # -------------------------------------        
@@ -414,7 +384,7 @@ class MagneticStructure(object):
     # -------------------------------------        
     # auxiliary functions
     # ------------------------------------- 
-    def print_attributes(self) -> None:
+    def get_attributes(self) -> None:
         """
         Prints all attribute of object
         """

--- a/barc4sr/aux_utils.py
+++ b/barc4sr/aux_utils.py
@@ -10,7 +10,7 @@ __contact__ = 'rafael.celestre@synchrotron-soleil.fr'
 __license__ = 'GPL-3.0'
 __copyright__ = 'Synchrotron SOLEIL, Saint Aubin, France'
 __created__ = '15/MAR/2024'
-__changed__ = '01/AUG/2024'
+__changed__ = '31/OCT/2024'
 
 import array
 import copy
@@ -1807,7 +1807,8 @@ def get_undulator_max_harmonic_number(resonant_energy: float, photonEnergyMax: f
         int: The maximum harmonic number.
     """
     srw_max_harmonic_number = int(photonEnergyMax / resonant_energy * 2.5)
-
+    if srw_max_harmonic_number < 5:
+        srw_max_harmonic_number = 5
     return srw_max_harmonic_number
 
 #***********************************************************************************

--- a/barc4sr/aux_utils.py
+++ b/barc4sr/aux_utils.py
@@ -221,7 +221,7 @@ class MagneticStructure(object):
     """
     Class for entering the magnetic structure parameters, which can represent an undulator, wiggler, or a bending magnet.
     """
-    def __init__(self, K_vertical: float = None, K_horizontal: float = None, 
+    def __init__(self, K_vertical: float = 0, K_horizontal: float = 0, 
                  B_horizontal: float = None, B_vertical: float = None, 
                  period_length: float = None, number_of_periods: int = None, 
                  radius: float = None, length: float = None, length_edge: float = 0, 

--- a/barc4sr/aux_utils.py
+++ b/barc4sr/aux_utils.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 from joblib import Parallel, delayed
 from scipy.constants import physical_constants
+from scipy.special import erf
 from skimage.restoration import unwrap_phase
 
 try:
@@ -196,6 +197,10 @@ class ElectronBeam(object):
         self.e_xp = np.sqrt(self.moment_xpxp)
         self.e_yp = np.sqrt(self.moment_ypyp)
 
+    def get_gamma(self) -> float:
+        """Calculate the Lorentz factor (γ) based on the energy of electrons in GeV."""
+        return get_gamma(self.energy_in_GeV)
+    
     def print_rms(self) -> None:
         """
         Prints electron beam rms sizes and divergences 
@@ -286,11 +291,14 @@ class MagneticStructure(object):
 
             if "v" in direction:
                 self.K_vertical = K
+
             elif "h" in direction:
                 self.K_horizontal = K
             else:
                 self.K_vertical = np.sqrt(K/2)
                 self.K_horizontal = np.sqrt(K/2)
+
+            self.set_magnetic_field_from_K(self.K_vertical, self.K_horizontal)
 
     def print_resonant_energy(self,  K: float, harmonic: int, eBeamEnergy: float) -> None:
         """
@@ -309,24 +317,52 @@ class MagneticStructure(object):
             energy = energy_wavelength(wavelength, 'm')
 
             print(f">> resonant energy {energy:.2f} eV")
+
     # -------------------------------------        
     # undulator/wiggler auxiliary functions
     # -------------------------------------        
-    def set_magnetic_field(self, B_horizontal: float=None, B_vertical: float=None) -> None:
+    def set_K_from_magnetic_field(self, B_horizontal: float=None, B_vertical: float=None) -> None:
         """
         Sets the K-value based on the magnetic field strength.
 
         Args:
-            Bx (float): Magnetic field strength in the horizontal direction.
-            By (float): Magnetic field strength in the vertical direction.
+            B_horizontal (float): Magnetic field strength in the horizontal direction.
+            B_vertical (float): Magnetic field strength in the vertical direction.
         """
         if self.CLASS_NAME.startswith('B'):
             raise ValueError("invalid operation for bending magnet")
         else:
             if B_horizontal is not None:
-                self.Kx = CHARGE * B_horizontal * self.period_length / (2 * PI * MASS * LIGHT)
+                self.K_horizontal = CHARGE * B_horizontal * self.period_length / (2 * PI * MASS * LIGHT)
+                self.B_horizontal = B_horizontal
             if B_vertical is not None:
-                self.Kx = CHARGE * B_vertical * self.period_length / (2 * PI * MASS * LIGHT)
+                self.K_vertical = CHARGE * B_vertical * self.period_length / (2 * PI * MASS * LIGHT)
+                self.B_vertical = B_vertical
+
+    def set_magnetic_field_from_K(self, K_horizontal: float=None, K_vertical: float=None) -> None:
+        """
+        Sets the magnetic field strength based on the K-value.
+
+        Args:
+            K_horizontal (float): K-value in the horizontal direction.
+            K_vertical (float): K-value in the vertical direction.
+        """
+        if self.CLASS_NAME.startswith('B'):
+            raise ValueError("invalid operation for bending magnet")
+        else:
+            if K_horizontal is not None:
+                if self.K_horizontal is None:
+                    self.B_horizontal = K_horizontal * 2 * PI * MASS * LIGHT / (CHARGE * self.period_length)
+                    self.K_horizontal = K_horizontal
+                else:
+                    self.B_horizontal = self.K_horizontal * 2 * PI * MASS * LIGHT / (CHARGE * self.period_length)
+            if K_vertical is not None:
+                if self.K_vertical is None:
+                    self.B_vertical = K_vertical * 2 * PI * MASS * LIGHT / (CHARGE * self.period_length)
+                    self.K_vertical = K_vertical
+                else:
+                    self.B_vertical = self.K_vertical * 2 * PI * MASS * LIGHT / (CHARGE * self.period_length)
+
     # -------------------------------------        
     # bending magnet auxiliary functions
     # -------------------------------------        
@@ -378,7 +414,7 @@ class MagneticStructure(object):
     # -------------------------------------        
     # auxiliary functions
     # ------------------------------------- 
-    def get_attributes(self) -> None:
+    def print_attributes(self) -> None:
         """
         Prints all attribute of object
         """

--- a/barc4sr/sr_undulator.py
+++ b/barc4sr/sr_undulator.py
@@ -36,6 +36,7 @@ from barc4sr.aux_utils import (
     get_gamma,
     print_elapsed_time,
     set_light_source,
+    set_magnetic_structure,
     srwlibCalcElecFieldSR,
     srwlibCalcStokesUR,
     srwlibsrwl_wfr_emit_prop_multi_e,
@@ -129,24 +130,33 @@ def spectrum(file_name: str,
     print(f"{function_txt} please wait...")
 
     energy_sampling = kwargs.get('energy_sampling', 0)
+
     observation_point = kwargs.get('observation_point', 10.)
+
     hor_slit = kwargs.get('hor_slit', 1e-3)
     ver_slit = kwargs.get('ver_slit', 1e-3)
     hor_slit_cen = kwargs.get('hor_slit_cen', 0)
     ver_slit_cen = kwargs.get('ver_slit_cen', 0)
+
     radiation_polarisation = kwargs.get('radiation_polarisation', 6)
+
     Kh = kwargs.get('Kh', -1)
     Kh_phase = kwargs.get('Kh_phase', 0)
     Kh_symmetry = kwargs.get('Kh_symmetry', 1)
+
     Kv = kwargs.get('Kv', -1)
     Kv_phase = kwargs.get('Kv_phase', 0)
     Kv_symmetry = kwargs.get('Kv_symmetry', 1)
+
     magnetic_measurement = kwargs.get('magnetic_measurement', None)
     tabulated_undulator_mthd = kwargs.get('tabulated_undulator_mthd', 0)
     electron_trajectory = kwargs.get('electron_trajectory', False)
+
     filament_beam = kwargs.get('filament_beam', False)
     energy_spread = kwargs.get('energy_spread', True)
+
     number_macro_electrons = kwargs.get('number_macro_electrons', 1)
+
     parallel = kwargs.get('parallel', False)
     num_cores = kwargs.get('num_cores', None)
 
@@ -318,18 +328,24 @@ def power_density(file_name: str,
     print("Undulator power density spatial distribution using SRW. Please wait...")
 
     observation_point = kwargs.get('observation_point', 10.)
+
     hor_slit_cen = kwargs.get('hor_slit_cen', 0)
     ver_slit_cen = kwargs.get('ver_slit_cen', 0)
+
     radiation_polarisation = kwargs.get('radiation_polarisation', 6)
+
     Kh = kwargs.get('Kh', -1)
     Kh_phase = kwargs.get('Kh_phase', 0)
     Kh_symmetry = kwargs.get('Kh_symmetry', 1)
+
     Kv = kwargs.get('Kv', -1)
     Kv_phase = kwargs.get('Kv_phase', 0)
     Kv_symmetry = kwargs.get('Kv_symmetry', 1)
+
     magnetic_measurement = kwargs.get('magnetic_measurement', None)
     tabulated_undulator_mthd = kwargs.get('tabulated_undulator_mthd', 0)
     electron_trajectory = kwargs.get('electron_trajectory', False)
+
     filament_beam = kwargs.get('filament_beam', False)
     energy_spread = kwargs.get('energy_spread', True)
 
@@ -451,22 +467,31 @@ def emitted_radiation(file_name: str,
     print(f"{function_txt} please wait...")
 
     energy_sampling = kwargs.get('energy_sampling', 0)
+
     observation_point = kwargs.get('observation_point', 10.)
+
     hor_slit_cen = kwargs.get('hor_slit_cen', 0)
     ver_slit_cen = kwargs.get('ver_slit_cen', 0)
+
     radiation_polarisation = kwargs.get('radiation_polarisation', 6)
+
     Kh = kwargs.get('Kh', -1)
     Kh_phase = kwargs.get('Kh_phase', 0)
     Kh_symmetry = kwargs.get('Kh_symmetry', 1)
+
     Kv = kwargs.get('Kv', -1)
     Kv_phase = kwargs.get('Kv_phase', 0)
     Kv_symmetry = kwargs.get('Kv_symmetry', 1)
+
     magnetic_measurement = kwargs.get('magnetic_measurement', None)
     tabulated_undulator_mthd = kwargs.get('tabulated_undulator_mthd', 0)
     electron_trajectory = kwargs.get('electron_trajectory', False)
+
     filament_beam = kwargs.get('filament_beam', False)
     energy_spread = kwargs.get('energy_spread', True)
+
     number_macro_electrons = kwargs.get('number_macro_electrons', -1)
+
     parallel = kwargs.get('parallel', False)
     num_cores = kwargs.get('num_cores', None)
 
@@ -610,21 +635,29 @@ def emitted_wavefront(file_name: str,
     print(f"{function_txt} please wait...")
 
     observation_point = kwargs.get('observation_point', 10.)
+
     hor_slit_cen = kwargs.get('hor_slit_cen', 0)
     ver_slit_cen = kwargs.get('ver_slit_cen', 0)
+
     radiation_polarisation = kwargs.get('radiation_polarisation', 6)
+
     Kh = kwargs.get('Kh', -1)
     Kh_phase = kwargs.get('Kh_phase', 0)
     Kh_symmetry = kwargs.get('Kh_symmetry', 1)
+
     Kv = kwargs.get('Kv', -1)
     Kv_phase = kwargs.get('Kv_phase', 0)
     Kv_symmetry = kwargs.get('Kv_symmetry', 1)
+
     magnetic_measurement = kwargs.get('magnetic_measurement', None)
     tabulated_undulator_mthd = kwargs.get('tabulated_undulator_mthd', 0)
     electron_trajectory = kwargs.get('electron_trajectory', False)
+
     filament_beam = kwargs.get('filament_beam', False)
     energy_spread = kwargs.get('energy_spread', True)
+
     number_macro_electrons = kwargs.get('number_macro_electrons', -1)
+
     parallel = kwargs.get('parallel', False)
     num_cores = kwargs.get('num_cores', None)
 
@@ -715,14 +748,15 @@ def emitted_wavefront(file_name: str,
 def coherent_modes():
     pass
 
-def tuning_cureve(file_name: str,
+def tuning_curve(file_name: str,
              json_file: str,
              photon_energy_min: float,
              photon_energy_max: float,
              photon_energy_points: int, 
+             nHarmMax: int,
              **kwargs) -> Dict:
     """
-    Calculate 1D undulator spectrum using SRW.
+    Calculate undulator tuning curve using SRW.
 
     Args:
         file_name (str): The name of the output file.
@@ -730,7 +764,7 @@ def tuning_cureve(file_name: str,
         photon_energy_min (float): Minimum photon energy [eV].
         photon_energy_max (float): Maximum photon energy [eV].
         photon_energy_points (int): Number of photon energy points.
-
+        nHarmMax (int): number of the highest harmonic to be takent into account.
     Optional Args (kwargs):
         energy_sampling (int): Energy sampling method (0: linear, 1: logarithmic). Default is 0.
         observation_point (float): Distance to the observation point. Default is 10 [m].
@@ -746,6 +780,7 @@ def tuning_cureve(file_name: str,
             =4 -Circular Right; 
             =5 -Circular Left; 
             =6 -Total
+        Kmin (float): Minimum K-value (cutt off for highest harmonic energy). Default is -1.
         Kh (float): Horizontal undulator parameter K. If -1, taken from the SYNED file. Default is -1.
         Kh_phase (float): Initial phase of the horizontal magnetic field [rad]. Default is 0.
         Kh_symmetry (int): Symmetry of the horizontal magnetic field vs longitudinal position.
@@ -775,29 +810,42 @@ def tuning_cureve(file_name: str,
 
     t0 = time.time()
 
-    function_txt = "Undulator spectrum calculation using SRW:"
+    function_txt = "Undulator K-tuning curve calculation using SRW:"
     calc_txt = "> Performing flux through finite aperture (___CALC___ partially-coherent simulation)"
     print(f"{function_txt} please wait...")
 
     energy_sampling = kwargs.get('energy_sampling', 0)
+
     observation_point = kwargs.get('observation_point', 10.)
+
+    even_harmonics = kwargs.get('even_harmonics', False)
+
     hor_slit = kwargs.get('hor_slit', 1e-3)
     ver_slit = kwargs.get('ver_slit', 1e-3)
     hor_slit_cen = kwargs.get('hor_slit_cen', 0)
     ver_slit_cen = kwargs.get('ver_slit_cen', 0)
+
     radiation_polarisation = kwargs.get('radiation_polarisation', 6)
+
+    Kmin = kwargs.get('Kmin', 1E-3)
+
     Kh = kwargs.get('Kh', -1)
     Kh_phase = kwargs.get('Kh_phase', 0)
     Kh_symmetry = kwargs.get('Kh_symmetry', 1)
+
     Kv = kwargs.get('Kv', -1)
     Kv_phase = kwargs.get('Kv_phase', 0)
     Kv_symmetry = kwargs.get('Kv_symmetry', 1)
+
     magnetic_measurement = kwargs.get('magnetic_measurement', None)
     tabulated_undulator_mthd = kwargs.get('tabulated_undulator_mthd', 0)
     electron_trajectory = kwargs.get('electron_trajectory', False)
+
     filament_beam = kwargs.get('filament_beam', False)
     energy_spread = kwargs.get('energy_spread', True)
+
     number_macro_electrons = kwargs.get('number_macro_electrons', 1)
+
     parallel = kwargs.get('parallel', False)
     num_cores = kwargs.get('num_cores', None)
 
@@ -815,7 +863,6 @@ def tuning_cureve(file_name: str,
                           hor_slit, ver_slit, hor_slit_cen, ver_slit_cen, 
                           Kh=Kh, Kh_phase=Kh_phase, Kh_symmetry=Kh_symmetry, 
                           Kv=Kv, Kv_phase=Kv_phase, Kv_symmetry=Kv_symmetry)
-
    
     eBeam, magFldCnt, eTraj = set_light_source(file_name, bl, filament_beam, 
                                                energy_spread, electron_trajectory, 'u',
@@ -823,42 +870,77 @@ def tuning_cureve(file_name: str,
                                                tabulated_undulator_mthd=tabulated_undulator_mthd)
 
     # ----------------------------------------------------------------------------------
-    # spectrum calculations
+    # tuning curve calculations
     # ----------------------------------------------------------------------------------
-    resonant_energy = get_emission_energy(bl['PeriodID'], 
-                                        np.sqrt(bl['Kv']**2 + bl['Kh']**2),
-                                        bl['ElectronEnergy'])
+
+    if nHarmMax > np.floor(photon_energy_max/photon_energy_min):
+        nHarmMax = int(np.floor(photon_energy_max/photon_energy_min))
+
     if energy_sampling == 0: 
         energy = np.linspace(photon_energy_min, photon_energy_max, photon_energy_points)
     else:
+
+        if np.sqrt(bl['Kv']**2 + bl['Kh']**2) == 0:
+            resonant_energy = photon_energy_min
+        else:
+            resonant_energy = get_emission_energy(bl['PeriodID'], 
+                                                np.sqrt(bl['Kv']**2 + bl['Kh']**2),
+                                                bl['ElectronEnergy'])
+
         stepsize = np.log(photon_energy_max/resonant_energy)
         energy = generate_logarithmic_energy_values(photon_energy_min,
                                                     photon_energy_max,
                                                     resonant_energy,
                                                     stepsize)
+
+    tc = np.zeros((len(energy), nHarmMax))
+    Kmap = np.zeros((len(energy)))-1
+    Emap = np.zeros((len(energy), nHarmMax))-1
+
+    for i, eng in enumerate(energy):
+        harm, K = find_emission_harmonic_and_K(eng, bl['PeriodID'],
+                                                  bl['ElectronEnergy'], 
+                                                  Kmin)         
+        if harm == 1:
+            Kmap[i] = K
+
+    for i in range(nHarmMax):
+        if even_harmonics and (i+1)%2 == 0:
+            Emap[:,i] = i*energy[0]+energy
+        elif (i+1)%2 != 0:
+            Emap[:,i] = i*energy[0]+energy
+
+    Emap[Emap>photon_energy_max] = -1
+
     # ---------------------------------------------------------
-    # On-Axis Spectrum from Filament Electron Beam
+    # On-Axis Tuning curve from Filament Electron Beam
     if calculation == 0:
         if parallel:
-            print('> Performing on-axis spectrum from filament electron beam in parallel ... ')
+            print('> Performing on-axis tuning curve from filament electron beam in parallel ... ')
         else:
-            print('> Performing on-axis spectrum from filament electron beam ... ', end='')
-
-        flux, h_axis, v_axis = srwlibCalcElecFieldSR(bl, 
-                                                     eBeam, 
-                                                     magFldCnt,
-                                                     energy,
-                                                     h_slit_points=1,
-                                                     v_slit_points=1,
-                                                     radiation_characteristic=0, 
-                                                     radiation_dependence=0,
-                                                     radiation_polarisation=radiation_polarisation,
-                                                     id_type='u',
-                                                     parallel=parallel,
-                                                     num_cores=num_cores)
-        flux = flux.reshape((photon_energy_points))
+            print('> Performing on-axis tuning curve from filament electron beam ... ', end='')
+        count = 0
+        for count, K in enumerate(Kmap):
+            if K>0:
+                bl['Kv'] = K
+                magFldCnt = set_magnetic_structure(bl, id_type='u',
+                                        magnetic_measurement = magnetic_measurement, 
+                                        tabulated_undulator_mthd = tabulated_undulator_mthd)
+                for nharm in range(nHarmMax):
+                    if Emap[count, nharm]>0:
+                        tc[count, nharm], h_axis, v_axis = srwlibCalcElecFieldSR(bl, 
+                                                                    eBeam, 
+                                                                    magFldCnt,
+                                                                    Emap[count, nharm],
+                                                                    h_slit_points=1,
+                                                                    v_slit_points=1,
+                                                                    radiation_characteristic=0, 
+                                                                    radiation_dependence=0,
+                                                                    radiation_polarisation=radiation_polarisation,
+                                                                    id_type='u',
+                                                                    parallel=parallel,
+                                                                    num_cores=num_cores)
         print('completed')
-
     # -----------------------------------------
     # Flux through Finite Aperture 
 
@@ -881,34 +963,34 @@ def tuning_cureve(file_name: str,
 
         print('completed')
 
-    # accurate partially-coherent simulation
-    if calculation == 2:
-        calc_txt = calc_txt.replace("___CALC___", "accurate")
-        if parallel:
-            print(f'{calc_txt} in parallel... ')
-        else:
-            print(f'{calc_txt} ... ', end='')
+    # # accurate partially-coherent simulation
+    # if calculation == 2:
+    #     calc_txt = calc_txt.replace("___CALC___", "accurate")
+    #     if parallel:
+    #         print(f'{calc_txt} in parallel... ')
+    #     else:
+    #         print(f'{calc_txt} ... ', end='')
 
-        flux, h_axis, v_axis = srwlibsrwl_wfr_emit_prop_multi_e(bl, 
-                                                                eBeam,
-                                                                magFldCnt,
-                                                                energy,
-                                                                h_slit_points=1,
-                                                                v_slit_points=1,
-                                                                radiation_polarisation=radiation_polarisation,
-                                                                id_type='u',
-                                                                number_macro_electrons=number_macro_electrons,
-                                                                aux_file_name=file_name,
-                                                                parallel=parallel,
-                                                                num_cores=num_cores)       
-        print('completed')
+    #     flux, h_axis, v_axis = srwlibsrwl_wfr_emit_prop_multi_e(bl, 
+    #                                                             eBeam,
+    #                                                             magFldCnt,
+    #                                                             energy,
+    #                                                             h_slit_points=1,
+    #                                                             v_slit_points=1,
+    #                                                             radiation_polarisation=radiation_polarisation,
+    #                                                             id_type='u',
+    #                                                             number_macro_electrons=number_macro_electrons,
+    #                                                             aux_file_name=file_name,
+    #                                                             parallel=parallel,
+    #                                                             num_cores=num_cores)       
+    #     print('completed')
 
-    write_spectrum(file_name, flux, energy)
+    # write_tuning_curve(file_name, flux, energy)
 
-    print(f"{function_txt} finished.")
-    print_elapsed_time(t0)
+    # print(f"{function_txt} finished.")
+    # print_elapsed_time(t0)
 
-    return {'energy':energy, 'flux':flux}
+    # return {'energy':energy, 'flux':flux}
 
 #***********************************************************************************
 # Magnetic field functions
@@ -1218,7 +1300,8 @@ def get_emission_energy(und_per: float, K: float, ring_e: float, n: int = 1, the
     return energy_wavelength(emission_wavelength, "m")
 
 
-def find_emission_harmonic_and_K(energy: float, und_per: float, ring_e: float, Kmin: float = 0.1, theta: float = 0) -> Tuple[int, float]:
+def find_emission_harmonic_and_K(energy: float, und_per: float, ring_e: float, Kmin: float = 0.1, theta: float = 0,
+                                 starting_harmonic: int = 1) -> Tuple[int, float]:
     """
     Find the emission harmonic number and undulator parameter K for a given energy in a storage ring.
 
@@ -1235,16 +1318,24 @@ def find_emission_harmonic_and_K(energy: float, und_per: float, ring_e: float, K
     Raises:
         ValueError: If no valid harmonic is found.
     """
-    count = 0
+    count = np.floor((starting_harmonic-1)/2)
     harm = 0
     gamma = get_gamma(ring_e)
     wavelength = energy_wavelength(energy, 'eV')
 
     while harm == 0:
         n = 2 * count + 1
-        K = np.sqrt(2 * ((2 * n * wavelength * gamma ** 2) / und_per - 1 - (gamma * theta) ** 2))
-        if K >= Kmin:
-            harm = int(n)
+        try:
+            arg_sqrt = 2 * ((2 * n * wavelength * gamma ** 2) / und_per - 1 - (gamma * theta) ** 2)
+            if arg_sqrt>=0:
+                K = np.sqrt(arg_sqrt)
+            else:
+                K=-1
+            if K >= Kmin:
+                harm = int(n)
+        except ValueError:
+            K = None
+
         count += 1
         # Break loop if no valid harmonic is found
         if count > 21:

--- a/barc4sr/sr_undulator.py
+++ b/barc4sr/sr_undulator.py
@@ -918,10 +918,6 @@ def tuning_curve(file_name: str,
     K[K>Kmax] = 0
     K[K<Kmin] = 0
 
-    l1 = energy_wavelength(photon_energy_min,'eV')
-    ls = l1 + 0.5*bl['PeriodID']*(np.amax([hor_slit,ver_slit])/observation_point)**2
-    DE = (energy_wavelength(l1,'m') - energy_wavelength(ls,'m'))*2
-
     # ---------------------------------------------------------
     # On-Axis Tuning curve from Filament Electron Beam
     if calculation == 0:    # TODO: implement analytical equation


### PR DESCRIPTION
Tuning curves for undulators are added to barc4sr. The on axis model works just fine, but the simplified partial coherent model works only for the cases where the slit is large enough to contain the full beam. For smaller slits, fixes will need to be implemented - these will slow down the calculations, but at least they will be more accurate.